### PR TITLE
a fix for slab creation

### DIFF
--- a/src/llm/ase_interface.py
+++ b/src/llm/ase_interface.py
@@ -11,7 +11,7 @@ import ase.build as build
 from ase.data import reference_states, atomic_numbers
 
 import numpy as np
-
+from ocdata.core import Adsorbate, AdsorbateSlabConfig, Bulk, Slab
 
 with open(Path("data", "input_data", "oc", "oc_20_adsorbates.pkl"), "rb") as f:
     oc_20_ads_structures = pickle.load(f)
@@ -143,10 +143,7 @@ def generate_bulk_ads_pairs(
     return new_bulk
 
 
-
-from ocdata.core import Adsorbate, AdsorbateSlabConfig, Bulk, Slab
-
-def generate_bulk_ads_pairs2(
+def generate_bulk_ads_pairs_heuristic(
     bulk: Atoms,
     ads: str,
     mode: str = "heuristic",

--- a/src/llm/ase_interface.py
+++ b/src/llm/ase_interface.py
@@ -156,7 +156,7 @@ def generate_bulk_ads_pairs2(
     bulk = Bulk(bulk_atoms=bulk)
     # specific_millers might have to be changed based on the type of the crystal (cubic, etc)
     slabs = Slab.from_bulk_get_specific_millers(bulk = bulk, specific_millers=(0,0,1))
-    slabs = [s for s in slabs if s.shift==0.0]
+    slabs = [s for s in slabs if s.shift==0.0] # selecting the slabs with shift=0
 
     
     binding_molecules = ads.info.get("binding_sites", np.array([0]))
@@ -169,7 +169,7 @@ def generate_bulk_ads_pairs2(
     if num_sites < len(heuristic_adslabs):
         adslabs = [heuristic_adslabs[i] for i in range(num_sites)]
 
-    if num_sites > len(heuristic_adslabs):
+    elif num_sites > len(heuristic_adslabs):
         num_random_slabs = (num_sites - len(heuristic_adslabs))//len(slabs)
 
         random_adslabs=[]

--- a/src/search/reward/simulation_reward.py
+++ b/src/search/reward/simulation_reward.py
@@ -208,7 +208,13 @@ class StructureReward(BaseReward):
                     elif placement_type == "adsml":
                         for ads_sym in ads_list:
                             ads_ats = ase_interface.ads_symbols_to_structure(ads_sym)
-                            slab_ats = ase_interface.symbols_list_to_bulk(slab_sym)
+                            # slab_ats = ase_interface.symbols_list_to_bulk(slab_sym)
+                            # slab_samples = [
+                            #     ase_interface.symbols_list_to_bulk(slab_sym)
+                            #     for _ in range(self.num_slab_samples)
+                            #     ]
+                            # slab_ats = self.adsorption_calculator.choose_slab(
+                            # slab_samples, slab_name)
                             slab_ats.center(vacuum=13.0, axis=2)
 
                             name = f"{slab_name}_{ads_sym}"
@@ -461,9 +467,9 @@ if __name__ == "__main__":
         # )
         print(
             sr2.create_structures_and_calculate(
-                [["Pt"]],
+                [["Cu","Pt"]],
                 ["CO"],
-                ["Pt"],
+                ["CuPt"],
                 placement_type="adsml",  # or None for random placement
             )
         )

--- a/src/search/reward/simulation_reward.py
+++ b/src/search/reward/simulation_reward.py
@@ -208,6 +208,9 @@ class StructureReward(BaseReward):
                     elif placement_type == "adsml":
                         for ads_sym in ads_list:
                             ads_ats = ase_interface.ads_symbols_to_structure(ads_sym)
+                            slab_ats = ase_interface.symbols_list_to_bulk(slab_sym)
+                            slab_ats.center(vacuum=13.0, axis=2)
+
                             name = f"{slab_name}_{ads_sym}"
                             adslab_ats += self.sample_adslabs2(slab_ats, ads_ats, name)
 
@@ -356,7 +359,7 @@ class StructureReward(BaseReward):
         adslabs = []
         # for i in range(self.num_adslab_samples):
         # print(slab.info)
-        adslab = ase_interface.generate_bulk_ads_pairs2(slab, ads)
+        adslab = ase_interface.generate_bulk_ads_pairs2(slab, ads, num_sites=self.num_adslab_samples)
         adslabs = [(i, name, adslab[i]) for i in range(len(adslab))]
 
         return adslabs
@@ -436,6 +439,7 @@ if __name__ == "__main__":
                 "traj_dir": Path("data", "output", f"adsml3"),
                 "device": "cpu",
                 "ads_tag": 2,
+                "num_adslab_samples": 1
             }
         )
         # print(
@@ -447,14 +451,23 @@ if __name__ == "__main__":
         #     )
         # )
 
+        # print(
+        #     sr2.create_structures_and_calculate(
+        #         [["Cu"], ["Pt"], ["Zr"]],
+        #         ["CO", "phenol", "anisole"],
+        #         ["Cu", "Pt", "Zr"],
+        #         placement_type="adsml",  # or None for random placement
+        #     )
+        # )
         print(
             sr2.create_structures_and_calculate(
-                [["Cu"], ["Pt"], ["Zr"]],
-                ["CO", "phenol", "anisole"],
-                ["Cu", "Pt", "Zr"],
+                [["Pt"]],
+                ["CO"],
+                ["Pt"],
                 placement_type="adsml",  # or None for random placement
             )
         )
+        
 
         for p in Path("data", "output", "adsml3").rglob("*.traj"):
             break_trajectory(p)


### PR DESCRIPTION
Some slabs returned by the `Slab.from_bulk_get_specific_millers()` had different number of layers than that of the original (`https://github.com/Open-Catalyst-Project/AdsorbML/issues/12`). Changed `generate_bulk_ads_pairs_heuristic` to take into account the slabs with `shift=0`. Renamed some functions to more meaningful names and added minor changes to `simulation_reward.py`.